### PR TITLE
Improve tag attributes system, add choices validation

### DIFF
--- a/lib/spark_components/attributes.rb
+++ b/lib/spark_components/attributes.rb
@@ -15,8 +15,10 @@ module SparkComponents
       # Output all attributes as [prefix-]name="value"
       def to_s
         each_with_object([]) do |(name, value), array|
-          if value.is_a?(self.class)
-            array << value.to_s
+          if value.is_a?(Attributes::Hash)
+            # Flatten nested hashs and inject them unless empty
+            value = value.to_s
+            array << value unless value.empty?
           else
             name = [prefix, name].compact.join("-").gsub(/[\W_]+/, "-")
             array << %(#{name}="#{value}") unless value.nil?
@@ -119,9 +121,8 @@ module SparkComponents
       end
 
       def root(obj = {})
-        attrs[:root] ||= Attributes::Hash.new
-        attrs[:root].add(obj) unless obj.empty?
-        attrs[:root]
+        attrs.add(obj) unless obj.empty?
+        attrs
       end
 
       def aria(obj = {})
@@ -149,6 +150,10 @@ module SparkComponents
       def base_class(name)
         classnames.base = name unless name.nil?
         classnames.base
+      end
+
+      def join_class(*args)
+        classnames.join_class(*args)
       end
 
       def new(obj = {})
@@ -181,8 +186,8 @@ module SparkComponents
           else
             case key.to_sym
             when :class then tag.classnames.add(val)
-            when :data, :aria, :root then tag.send(key).add(val)
-            else; tag.root[key] = val
+            when :data, :aria then tag.send(key).add(val)
+            else; tag.attrs[key] = val
             end
           end
         end

--- a/lib/spark_components/attributes.rb
+++ b/lib/spark_components/attributes.rb
@@ -5,25 +5,40 @@ module SparkComponents
     class Hash < Hash
       def prefix; end
 
-      def add(obj = nil)
-        merge!(obj) unless obj.nil?
+      def add(*args)
+        args.each do |arg|
+          arg.is_a?(::Hash) ? self.merge!(arg) : self[arg.to_sym] = nil
+        end
         self
       end
 
-      # Output all attributes as [base-]name="value"
+      # Output all attributes as [prefix-]name="value"
       def to_s
-        each_with_object([]) do |(name, value), array|
-          name = [prefix, name].compact.join("-")
-          array << %(#{name.dasherize}="#{value}") unless value.nil?
-        end.join(" ").html_safe
+        str = each_with_object([]) do |(name, value), array|
+          if value.is_a?(self.class)
+            array << value.to_s
+          else
+            name = [prefix, name].compact.join("-").gsub(/[\W_]+/, '-')
+            array << %(#{name}="#{value}") unless value.nil?
+          end
+        end.sort.join(" ")
+        str.respond_to?(:html_safe) ? str.html_safe : str
       end
 
+      # Return a prefix flattened hash,
+      # For example: { "toggle"=>"div" } -> { "data-toggle"=>"div" }
       def collapse
         each_with_object({}) do |(name, value), obj|
           name = [prefix, name].compact.join("-")
           name = name.downcase.gsub(/[\W_]+/, "-")
           obj[name] = value unless value.nil? || value.is_a?(String) && value.empty?
         end
+      end
+
+      # Easy assess to create a new Attributes::Hash
+      def new(*args)
+        new_obj = self.class.new
+        new_obj.add(*args)
       end
     end
 
@@ -57,7 +72,7 @@ module SparkComponents
       # Ensure base class is the first element in the classes array.
       #
       def base=(klass)
-        return if klass.blank?
+        return if klass.nil? || klass.empty?
 
         if @base_set
           self[0] = klass
@@ -79,11 +94,95 @@ module SparkComponents
       end
 
       def add(*args)
-        push(*args.uniq.reject { |a| a.nil? || include?(a) })
+        push(*args.flatten.uniq.reject { |a| a.nil? || include?(a) })
+        self
+      end
+
+      # Easy assess to create a new Attributes::Classname
+      def new(*args)
+        new_arr = self.class.new
+
+        unless args.empty?
+          new_arr.base = args.shift
+          new_arr.add(*args)
+        end
+
+        new_arr
       end
 
       def to_s
-        join(" ").html_safe
+        safe join(" ")
+      end
+
+      def safe(str)
+        str.respond_to?(:html_safe) ? str.html_safe : str
+      end
+    end
+
+    class Tag
+      attr_reader :attrs
+
+      def initialize(obj={})
+        @attrs = Hash.new
+        merge!(obj)
+      end
+
+      def data
+        attrs[:data] ||= Data.new
+      end
+
+      def aria
+        attrs[:aria] ||= Aria.new
+      end
+
+      def classnames
+        attrs[:class] ||= Classname.new
+      end
+
+      def root
+        attrs[:root] ||= Hash.new
+      end
+
+      def new(obj={})
+        self.class.new(obj)
+      end
+
+      # Ensure each attribute is distinct
+      def dup
+        new(attrs.each_with_object(Hash.new) do |(k, v), obj|
+          obj[k] = v.dup
+        end)
+      end
+
+      def merge!(obj={})
+        merge_obj(self, obj)
+      end
+
+      def merge(obj={})
+        merge_obj(dup, obj)
+      end
+
+      def merge_obj(tag, obj={})
+        # If merging another Tag, extract attrs to merge
+        obj = obj.attrs if obj.is_a?(Tag)
+
+        obj.each do |key, val|
+          if val.is_a?(Classname)
+            # preserve object state
+            tag.attrs[:class] = val;
+          else
+            case key.to_sym
+            when :class; tag.classnames.add(val)
+            when :data, :aria, :root; tag.send(key).add(val)
+            else; tag.root[key] = val
+            end
+          end
+        end
+        tag
+      end
+
+      def to_s
+        attrs.to_s
       end
     end
   end

--- a/lib/spark_components/attributes.rb
+++ b/lib/spark_components/attributes.rb
@@ -14,7 +14,7 @@ module SparkComponents
 
       # Output all attributes as [prefix-]name="value"
       def to_s
-        str = each_with_object([]) do |(name, value), array|
+        each_with_object([]) do |(name, value), array|
           if value.is_a?(self.class)
             array << value.to_s
           else
@@ -22,17 +22,6 @@ module SparkComponents
             array << %(#{name}="#{value}") unless value.nil?
           end
         end.sort.join(" ")
-        str.respond_to?(:html_safe) ? str.html_safe : str
-      end
-
-      # Return a prefix flattened hash,
-      # For example: { "toggle"=>"div" } -> { "data-toggle"=>"div" }
-      def collapse
-        each_with_object({}) do |(name, value), obj|
-          name = [prefix, name].compact.join("-")
-          name = name.downcase.gsub(/[\W_]+/, "-")
-          obj[name] = value unless value.nil? || value.is_a?(String) && value.empty?
-        end
       end
 
       # Easy assess to create a new Attributes::Hash
@@ -111,11 +100,7 @@ module SparkComponents
       end
 
       def to_s
-        safe join(" ")
-      end
-
-      def safe(str)
-        str.respond_to?(:html_safe) ? str.html_safe : str
+        join(" ")
       end
     end
 

--- a/lib/spark_components/element.rb
+++ b/lib/spark_components/element.rb
@@ -41,24 +41,24 @@ module SparkComponents
       end
     end
 
-    def self.base_class(name)
-      tag_attrs.classnames.base = name
+    def self.base_class(name = nil)
+      tag_attrs.base_class(name)
     end
 
     def self.add_class(*args)
-      tag_attrs.classnames.add(*args)
+      tag_attrs.add_class(*args)
     end
 
     def self.data_attr(*args)
-      tag_attrs.data.add(attribute(*args))
+      tag_attrs.data(attribute(*args))
     end
 
     def self.aria_attr(*args)
-      tag_attrs.aria.add(attribute(*args))
+      tag_attrs.aria(attribute(*args))
     end
 
     def self.root_attr(*args)
-      tag_attrs.root.add(attribute(*args))
+      tag_attrs.root(attribute(*args))
     end
 
     def self.tag_attrs
@@ -66,11 +66,12 @@ module SparkComponents
     end
 
     def self.validates_choice(name, choices)
-      validates(name, inclusion: {
-        presence: true,
-        in: choices,
-        message: "\"%{value}\" is not a valid option. Options include: #{choices.join(", ")}"
-      })
+      validates(name,
+                inclusion: {
+                  presence: true,
+                  in: choices,
+                  message: "\"%{value}\" is not a valid option. Options include: #{choices.join(', ')}"
+                })
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -157,8 +158,8 @@ module SparkComponents
       @parents.last
     end
 
-    def classnames
-      @tag_attrs.classnames
+    def classnames(*args)
+      @tag_attrs.classnames(*args)
     end
 
     def base_class(name = nil)
@@ -167,23 +168,23 @@ module SparkComponents
     end
 
     def add_class(*args)
-      classnames.add(*args)
+      classnames(*args)
     end
 
-    def join_class(name, separator: "-")
-      [base_class, name].join(separator) unless base_class.nil?
+    def join_class(*args)
+      classnames.join_class(*args)
     end
 
     def data_attr(*args)
-      @tag_attrs.data.add(*args)
+      @tag_attrs.data(*args)
     end
 
     def aria_attr(*args)
-      @tag_attrs.aria.add(*args)
+      @tag_attrs.aria(*args)
     end
 
     def root_attr(*args)
-      @tag_attrs.root.add(*args)
+      @tag_attrs.root(*args)
     end
 
     def tag_attrs

--- a/lib/spark_components/element.rb
+++ b/lib/spark_components/element.rb
@@ -42,27 +42,27 @@ module SparkComponents
     end
 
     def self.base_class(name)
-      attrs.classnames.base = name
+      tag_attrs.classnames.base = name
     end
 
     def self.add_class(*args)
-      attrs.classnames.add(*args)
+      tag_attrs.classnames.add(*args)
     end
 
     def self.data_attr(*args)
-      attrs.data.add(attribute(*args))
+      tag_attrs.data.add(attribute(*args))
     end
 
     def self.aria_attr(*args)
-      attrs.aria.add(attribute(*args))
+      tag_attrs.aria.add(attribute(*args))
     end
 
     def self.root_attr(*args)
-      attrs.root.add(attribute(*args))
+      tag_attrs.root.add(attribute(*args))
     end
 
-    def self.attrs
-      @attrs ||= SparkComponents::Attributes::Tag.new
+    def self.tag_attrs
+      @tag_attrs ||= SparkComponents::Attributes::Tag.new
     end
 
     def self.validates_choice(name, choices)
@@ -129,14 +129,14 @@ module SparkComponents
       attributes.each { |name, options| subclass.set_attribute(name, options.dup) }
       elements.each   { |name, options| subclass.elements[name] = options.dup }
 
-      subclass.attrs.merge!(attrs.dup)
+      subclass.tag_attrs.merge!(tag_attrs.dup)
     end
 
     def initialize(view, attributes = nil, &block)
       @view = view
       attributes ||= {}
-      initialize_attrs
-      assign_attrs(attributes)
+      initialize_tag_attrs
+      assign_tag_attrs(attributes)
       initialize_attributes(attributes)
       initialize_elements
       extend_view_methods
@@ -158,7 +158,7 @@ module SparkComponents
     end
 
     def classnames
-      @attrs.classnames
+      @tag_attrs.classnames
     end
 
     def base_class(name = nil)
@@ -175,21 +175,19 @@ module SparkComponents
     end
 
     def data_attr(*args)
-      @attrs.data.add(*args)
+      @tag_attrs.data.add(*args)
     end
 
     def aria_attr(*args)
-      @attrs.aria.add(*args)
+      @tag_attrs.aria.add(*args)
     end
 
     def root_attr(*args)
-      @attrs.root.add(*args)
+      @tag_attrs.root.add(*args)
     end
 
-    def tag_attrs(add_class: true)
-      atr = @attrs.attrs
-      atr.delete(:class) unless add_class
-      atr
+    def tag_attrs
+      @tag_attrs.attrs
     end
 
     def to_s
@@ -206,9 +204,9 @@ module SparkComponents
     protected
 
     # Set tag attribute values from from parameters
-    def update_attr(name)
+    def update_tag_attr(name)
       %i[aria data root].each do |el|
-        @attrs.send(el)[name] = get_instance_variable(name) if @attrs.send(el).key?(name)
+        @tag_attrs.send(el)[name] = get_instance_variable(name) if @tag_attrs.send(el).key?(name)
       end
     end
 
@@ -216,12 +214,12 @@ module SparkComponents
       @view.render(partial: file, object: self)
     end
 
-    def initialize_attrs
-      @attrs = self.class.attrs.dup
+    def initialize_tag_attrs
+      @tag_attrs = self.class.tag_attrs.dup
     end
 
     # Assign tag attributes from arguments
-    def assign_attrs(attributes)
+    def assign_tag_attrs(attributes)
       # support default data, class, and aria attribute names
       data_attr(attributes.delete(:data)) if attributes[:data]
       aria_attr(attributes.delete(:aria)) if attributes[:aria]
@@ -232,7 +230,7 @@ module SparkComponents
     def initialize_attributes(attributes)
       self.class.attributes.each do |name, options|
         set_instance_variable(name, attributes[name] || (options[:default] && options[:default].dup))
-        update_attr(name)
+        update_tag_attr(name)
       end
     end
 

--- a/lib/spark_components/element.rb
+++ b/lib/spark_components/element.rb
@@ -54,7 +54,8 @@ module SparkComponents
     end
 
     def self.aria_attr(*args)
-      tag_attrs.aria(attribute(*args))
+      arg = attribute(*args)
+      tag_attrs.aria(arg)
     end
 
     def self.root_attr(*args)

--- a/lib/spark_components/version.rb
+++ b/lib/spark_components/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SparkComponents
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/spark_components.gemspec
+++ b/spark_components.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.version     = SparkComponents::VERSION
   s.authors     = ["Brandon Mathis"]
   s.email       = ["brandon@imathis.com"]
-  s.homepage    = "https://github.com/imathis/spark_components"
+  s.homepage    = "https://github.com/spark-engine/components"
   s.summary     = "Simple view components for Rails 5.1+"
   s.description = "Simple view components for Rails 5.1+"
   s.license     = "MIT"

--- a/test/attributes_test.rb
+++ b/test/attributes_test.rb
@@ -57,4 +57,24 @@ class AttributesTest < ActiveSupport::TestCase
     assert_equal "blast", attr.base.to_s
     assert_equal "blast foo bar", attr.to_s
   end
+
+  test "Tag manages aria, class, data, and root level attributes" do
+    tag_attr = SparkComponents::Attributes::Tag.new
+
+    tag_attr.root(foo: "bar")
+    assert_equal %(foo="bar"), tag_attr.to_s
+
+    tag_attr.aria(foo: "bar")
+    assert_equal %(aria-foo="bar"), tag_attr.aria.to_s
+    assert_equal %(aria-foo="bar" foo="bar"), tag_attr.to_s
+
+    tag_attr.data(foo: "bar")
+    assert_equal %(data-foo="bar"), tag_attr.data.to_s
+    assert_equal %(aria-foo="bar" data-foo="bar" foo="bar"), tag_attr.to_s
+
+    tag_attr.add_class("foo")
+    tag_attr.base_class("base")
+    assert_equal %(aria-foo="bar" class="base foo" data-foo="bar" foo="bar"), tag_attr.to_s
+    assert_equal %(base-bar), tag_attr.join_class("bar")
+  end
 end

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -242,7 +242,7 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize with given attribute and successfull choice validation" do
     component_class = Class.new(SparkComponents::Component) do
       attribute :foo
-      validates_choice :foo, %w(bar baz)
+      validates_choice :foo, %w[bar baz]
     end
     assert_nothing_raised { component_class.new(view_class.new, foo: "bar") }
   end
@@ -250,12 +250,13 @@ class ComponentTest < ActiveSupport::TestCase
   test "initialize with given attribute and invalid choice validation" do
     component_class = Class.new(SparkComponents::Component) do
       attribute :size
-      validates_choice :size, %w(small medium large)
+      validates_choice :size, %w[small medium large]
     end
     e = assert_raises(ActiveModel::ValidationError) do
       component_class.new(view_class.new, size: "orange")
     end
-    assert_equal "Validation failed: Size \"orange\" is not a valid option. Options include: small, medium, large", e.message
+    assert_equal "Validation failed: Size \"orange\" is not a valid option.\
+      Options include: small, medium, large", e.message
   end
 
   test "element can render a component" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -292,8 +292,8 @@ class ComponentTest < ActiveSupport::TestCase
     component = component_class.new(view_class.new, class: "four five")
 
     assert_equal "one two three four five", component.classnames.to_s
-    assert_equal :one, component.classnames.base
     assert_equal "one-two", component.join_class("two")
+    assert_equal :one, component.classnames.base
   end
 
   test "tag_attr defines component attributes which can modify root tag attributes" do
@@ -301,10 +301,10 @@ class ComponentTest < ActiveSupport::TestCase
       tag_attr :foo, :bar, a: "b"
     end
     component = component_class.new(view_class.new, foo: "baz")
-    assert_equal %(foo="baz" a="b"), component.tag_attr.to_s
+    assert_equal %(a="b" foo="baz"), component.tag_attr.to_s
 
     component.tag_attr.add bar: true
-    assert_equal %(foo="baz" bar="true" a="b"), component.tag_attr.to_s
+    assert_equal %(a="b" bar="true" foo="baz"), component.tag_attr.to_s
   end
 
   test "splat option allows assignment of root tag attributes" do
@@ -313,7 +313,7 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal %(foo="baz"), component.tag_attr.to_s
 
     component.tag_attr.add bar: true
-    assert_equal %(foo="baz" bar="true"), component.tag_attr.to_s
+    assert_equal %(bar="true" foo="baz"), component.tag_attr.to_s
   end
 
   test "data_attr defines component attributes which can modify data- attributes" do
@@ -321,10 +321,10 @@ class ComponentTest < ActiveSupport::TestCase
       data_attr :foo, :bar, a: "b"
     end
     component = component_class.new(view_class.new, foo: "baz")
-    assert_equal %(data-foo="baz" data-a="b"), component.data_attr.to_s
+    assert_equal %(data-a="b" data-foo="baz"), component.data_attr.to_s
 
     component.data_attr bar: true
-    assert_equal %(data-foo="baz" data-bar="true" data-a="b"), component.data_attr.to_s
+    assert_equal %(data-a="b" data-bar="true" data-foo="baz"), component.data_attr.to_s
   end
 
   test "aria_attr defines component attributes which can modify aria- attributes" do
@@ -332,10 +332,10 @@ class ComponentTest < ActiveSupport::TestCase
       aria_attr :foo, :bar, a: "b"
     end
     component = component_class.new(view_class.new, foo: "baz")
-    assert_equal %(aria-foo="baz" aria-a="b"), component.aria_attr.to_s
+    assert_equal %(aria-a="b" aria-foo="baz"), component.aria_attr.to_s
 
     component.aria_attr bar: true
-    assert_equal %(aria-foo="baz" aria-bar="true" aria-a="b"), component.aria_attr.to_s
+    assert_equal %(aria-a="b" aria-bar="true" aria-foo="baz"), component.aria_attr.to_s
   end
 
   test "data, class, and aria component options sets default attributes" do
@@ -353,8 +353,8 @@ class ComponentTest < ActiveSupport::TestCase
     end
     component = component_class.new(view_class.new, data: { foo: "bar" }, class: "one two", aria: { three: "four" })
 
-    assert_equal %(class="one two" data-foo="bar" aria-three="four" role="nav" id="foo"), component.attrs.to_s
-    assert_equal %(data-foo="bar" aria-three="four" role="nav" id="foo"), component.attrs(add_class: false).to_s
+    assert_equal %(aria-three="four" class="one two" data-foo="bar" id="foo" role="nav"), component.attrs.to_s
+    assert_equal %(aria-three="four" data-foo="bar" id="foo" role="nav"), component.attrs(add_class: false).to_s
   end
 
   test "tag attributes are isolated across components" do
@@ -383,40 +383,6 @@ class ComponentTest < ActiveSupport::TestCase
 
     assert_equal %(type="default"), component.tag_attr.to_s
     assert_equal %(type="alert"), component_2.tag_attr.to_s
-  end
-
-  # Themes
-
-  test "components can have themes with defaults" do
-    component_class = Class.new(SparkComponents::Component) do
-      add_theme default: "foo"
-    end
-    component = component_class.new(view_class.new)
-
-    assert_equal "foo", component.classnames.to_s
-  end
-
-  test "supports multiple themes" do
-    component_class = Class.new(SparkComponents::Component) do
-      add_theme default: :test, foo: "bar"
-    end
-
-    component = component_class.new(view_class.new, theme: :foo)
-    component_2 = component_class.new(view_class.new)
-
-    assert_equal "bar", component.classnames.to_s
-    assert_equal "test", component_2.classnames.to_s
-  end
-
-  test "adding an unsupported theme fails" do
-    component_class = Class.new(SparkComponents::Component) do
-      add_theme default: :test, alt: "alternate"
-    end
-
-    e = assert_raises(SparkComponents::Error) do
-      component_class.new(view_class.new, theme: :foo)
-    end
-    assert_equal "Unsupported theme: :foo is not a valid theme. Try: :default, :alt.", e.message
   end
 
   private

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -373,7 +373,6 @@ class ComponentTest < ActiveSupport::TestCase
     component = component_class.new(view_class.new, data: { foo: "bar" }, class: "one two", aria: { three: "four" })
 
     assert_equal %(aria-three="four" class="one two" data-foo="bar" id="foo" role="nav"), component.tag_attrs.to_s
-    assert_equal %(aria-three="four" data-foo="bar" id="foo" role="nav"), component.tag_attrs(add_class: false).to_s
   end
 
   test "tag attributes are isolated across components" do

--- a/test/component_test.rb
+++ b/test/component_test.rb
@@ -256,7 +256,7 @@ class ComponentTest < ActiveSupport::TestCase
       component_class.new(view_class.new, size: "orange")
     end
     assert_equal "Validation failed: Size \"orange\" is not a valid option.\
-      Options include: small, medium, large", e.message
+ Options include: small, medium, large", e.message
   end
 
   test "element can render a component" do
@@ -400,8 +400,8 @@ class ComponentTest < ActiveSupport::TestCase
     assert_equal %(aria-type="default"), component.aria_attr.to_s
     assert_equal %(aria-type="alert"), component_2.aria_attr.to_s
 
-    assert_equal %(type="default"), component.root_attr.to_s
-    assert_equal %(type="alert"), component_2.root_attr.to_s
+    assert_equal "default", component.tag_attrs[:type]
+    assert_equal "alert", component_2.tag_attrs[:type]
   end
 
   private


### PR DESCRIPTION
This shifts more of the tag attribute management from elements to attribute classes. Now it is possible to create a tag attributes hash which manages classnames, aria, data, and root tag attributes. These can be merged, duped, and converted to attribute strings.

## Attribute management
Create a new tag attribute instance with `tag_attrs.new`, then manage its elements like this.

```ruby
input_attrs = tag_attrs.new
input_attrs.root(type: "checkbox")
input_attrs.data(foo: "bar")
input_attrs.aria(label: "bar")
input_attrs.base_class = "switch-input"
input_attrs.add_class("small") if size == "small"
```

Or you can specify the attributes inline.

```ruby
input_attrs = tag_attrs.new(type: "checkbox", aria: { label: "bar" }, data: { foo: "bar"}, class: size)
input_attrs.base_class = "switch-input"
```

Note that base_class must be set directly as we want to avoid inferring a base class.

## Validate Choice

Components support [ActiveModel Validations](https://guides.rubyonrails.org/active_record_validations.html) which are really powerful but can be verbose. As a convenience, this adds `validates_choice` which ensures that a component attribute is set to one of the allowable choices. It looks like this.

```ruby
attribute size: "medium"
validates_choice :size, %w[small medium large]
```

This will default the size to medium, and ensure that only "small", "medium", and "large" are valid choices. Throwing an error,

```
Size "orange" is not a valid option. Options include: small, medium, large"
```